### PR TITLE
Bump redis dependency version

### DIFF
--- a/charts/seqr/Chart.lock
+++ b/charts/seqr/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.1.0
-digest: sha256:cec8d2bee947234d49f9934e5b9fe9e0a0ac9591a7e0a17431d09f0697b5d092
-generated: "2022-08-29T13:49:58.882266-04:00"
+  version: 17.1.6
+digest: sha256:7ef3ec66c5d6f614617c475e8e10d16b5c769306b83ff8ebcba29a5479a4bf5a
+generated: "2022-10-18T15:29:33.368639-04:00"

--- a/charts/seqr/Chart.yaml
+++ b/charts/seqr/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/seqr/Chart.yaml
+++ b/charts/seqr/Chart.yaml
@@ -26,6 +26,6 @@ appVersion: "d619e7cf6d367b43aec9e92890e69ecece683c5f"
 # Dependencies that should be deployed along with this chart
 dependencies:
   - name: redis
-    version: 17.1.0
+    version: 17.1.6
     repository: "https://charts.bitnami.com/bitnami"
     condition: redis.enabled


### PR DESCRIPTION
This PR shows how to update our redis dependency.

The first step is updating the version number of the redis chart in Chart.yaml. You can find the available versions of the chart with the helm search repo command:

```bash
helm repo add bitnami https://charts.bitnami.com/bitnami  # only necessary if you haven't added the repo before
helm search repo bitnami/redis --versions
```

After you've dropped the new version number in the Chart.yaml file, run `helm dep update` to update the digest in the Chart.lock file, and then commit both files.

A final optional step is to update the `version` of the seqr helm chart itself. Doing that will trigger a chart release workflow after this PR merges. You would want to do that if your changes are ready to deploy, or you might want to hold off on updating the version if you know you've got more chart changes to make before your next deployment.