### PR TITLE
Copy cached reference dataset queries during pod init.

### DIFF
--- a/charts/hail-search/Chart.yaml
+++ b/charts/hail-search/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.12
+version: 0.1.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hail-search/Chart.yaml
+++ b/charts/hail-search/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hail-search/values.yaml
+++ b/charts/hail-search/values.yaml
@@ -80,8 +80,6 @@ nodeSelector:
 
 sourceCachedReferenceDatasetQueriesDir: 'gs://seqr-reference-data/v03'
 cachedReferenceDatasetQueries:
-  GRCh37/SNV_INDEL:
-    - 'GRCh37/cached_reference_dataset_queries/clinvar_path_variants.ht'
   GRCh38/SNV_INDEL:
     - 'GRCh38/cached_reference_dataset_queries/clinvar_path_variants.ht'
   GRCh38/MITO:

--- a/charts/hail-search/values.yaml
+++ b/charts/hail-search/values.yaml
@@ -42,7 +42,17 @@ initContainers: |-
     volumeMounts:
       - mountPath: {{ $.Values.environment.DATASETS_DIR }}
         name: datasets
+  {{ end -}}
   {{ end }}
+  {{- range $path, $queries := $.Values.cachedReferenceDatasetQueries -}}
+  {{- range $query := $queries -}}
+  - name: sync-cached-reference-dataset-queries-{{ $path | replace "/" "-" | replace "_" "-" | lower}}
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
+    command: ['gsutil', '-m', 'cp', '-r', '{{ $.Values.sourceCachedReferenceDatasetQueriesDir }}/{{ $query }}', '{{ $.Values.environment.DATASETS_DIR }}/{{ $path }}']
+    volumeMounts:
+      - mountPath: {{ $.Values.environment.DATASETS_DIR }}
+        name: datasets
+  {{ end -}}
   {{ end }}
 
 # Prefer to be scheduled away from other hail-search pods and seqr application pods
@@ -67,6 +77,16 @@ affinity: |-
 
 nodeSelector: 
   {}
+
+sourceCachedReferenceDatasetQueriesDir: 'gs://seqr-reference-data/v03'
+cachedReferenceDatasetQueries:
+  GRCh37/SNV_INDEL:
+    - 'GRCh37/cached_reference_dataset_queries/clinvar_path_variants.ht'
+  GRCh38/SNV_INDEL:
+    - 'GRCh38/cached_reference_dataset_queries/clinvar_path_variants.ht'
+  GRCh38/MITO:
+    - 'GRCh38/cached_reference_dataset_queries/clinvar_path_variants.ht'
+    - 'GRCh38/cached_reference_dataset_queries/high_af_variants.ht'
 
 global:
   hail_search:

--- a/charts/hail-search/values.yaml
+++ b/charts/hail-search/values.yaml
@@ -54,7 +54,7 @@ initContainers: |-
   {{- range $query := $queries -}}
   - name: sync-cached-reference-dataset-queries-{{ $path | replace "/" "-" | replace "_" "-" | lower}}
     image: gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
-    command: ['gsutil', '-m', 'cp', '-r', '{{ $.Values.sourceCachedReferenceDatasetQueriesDir }}/{{ $path }}/cached_reference_dataset_queries/{{ $query }}', '{{ $.Values.environment.DATASETS_DIR }}/{{ $path }}']
+    command: ['gsutil', '-m', 'cp', '-r', '{{ $.Values.sourceCachedReferenceDatasetQueriesDir }}/{{ $path }}/cached_reference_dataset_queries/{{ $query }}.ht', '{{ $.Values.environment.DATASETS_DIR }}/{{ $path }}']
     volumeMounts:
       - mountPath: {{ $.Values.environment.DATASETS_DIR }}
         name: datasets

--- a/charts/hail-search/values.yaml
+++ b/charts/hail-search/values.yaml
@@ -54,7 +54,7 @@ initContainers: |-
   {{- range $query := $queries -}}
   - name: sync-cached-reference-dataset-queries-{{ $path | replace "/" "-" | replace "_" "-" | lower}}
     image: gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
-    command: ['gsutil', '-m', 'cp', '-r', '{{ $.Values.sourceCachedReferenceDatasetQueriesDir }}/{{ $query }}', '{{ $.Values.environment.DATASETS_DIR }}/{{ $path }}']
+    command: ['gsutil', '-m', 'cp', '-r', '{{ $.Values.sourceCachedReferenceDatasetQueriesDir }}/{{ $path }}/cached_reference_dataset_queries/{{ $query }}', '{{ $.Values.environment.DATASETS_DIR }}/{{ $path }}']
     volumeMounts:
       - mountPath: {{ $.Values.environment.DATASETS_DIR }}
         name: datasets
@@ -87,10 +87,10 @@ nodeSelector:
 sourceCachedReferenceDatasetQueriesDir: 'gs://seqr-reference-data/v03'
 cachedReferenceDatasetQueries:
   GRCh38/SNV_INDEL:
-    - 'GRCh38/cached_reference_dataset_queries/clinvar_path_variants.ht'
+    - 'clinvar_path_variants'
+    - 'high_af_variants'
   GRCh38/MITO:
-    - 'GRCh38/cached_reference_dataset_queries/clinvar_path_variants.ht'
-    - 'GRCh38/cached_reference_dataset_queries/high_af_variants.ht'
+    - 'clinvar_path_variants'
 
 global:
   hail_search:


### PR DESCRIPTION
My first pass had us copying these in airflow into the run directories, but this is cleaner.