### PR TITLE
adjust search pod liveness probe

### DIFF
--- a/charts/hail-search/templates/deployment.yaml
+++ b/charts/hail-search/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           livenessProbe:
             initialDelaySeconds: 10
             periodSeconds: 30
-            failureThreshold: 5
+            failureThreshold: 10
             httpGet:
               path: /status
               port: http

--- a/charts/hail-search/templates/deployment.yaml
+++ b/charts/hail-search/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
               port: http
           readinessProbe:
             initialDelaySeconds: 10
-            periodSeconds: 30
+            periodSeconds: 60
             failureThreshold: 5
             httpGet:
               path: /status

--- a/charts/hail-search/templates/deployment.yaml
+++ b/charts/hail-search/templates/deployment.yaml
@@ -47,8 +47,8 @@ spec:
               protocol: TCP
           livenessProbe:
             initialDelaySeconds: 10
-            periodSeconds: 30
-            failureThreshold: 10
+            periodSeconds: 60
+            failureThreshold: 5
             httpGet:
               path: /status
               port: http


### PR DESCRIPTION
The liveness probe currently sends a status check every 30 seconds and if a response is not received after 5 checks the pod restarts. This means that if a search runs for longer than 2:30, the pod restarts. Since we know we have searches that we know will run longer than that, this is not desirable behavior, so I am increasing the allowed number of failed probes