### PR TITLE
Add name label to `seqr` and `seqr` `CronJob` pods.

### DIFF
--- a/charts/seqr/templates/cronjob.yaml
+++ b/charts/seqr/templates/cronjob.yaml
@@ -5,6 +5,7 @@ kind: CronJob
 metadata:
   name: {{ $.Chart.Name }}-{{- $c.name }}
   labels:
+    name: {{ $.Chart.Name }}-{{- $c.name }}
     {{- include "seqr.labels" $ | nindent 4 }}
 spec:
   schedule: {{ toYaml $c.schedule }}
@@ -20,6 +21,7 @@ spec:
         metadata:
           name: {{ $.Chart.Name }}-{{- $c.name }}
           labels:
+            name: {{ $.Chart.Name }}-{{- $c.name }}
             {{- include "seqr.labels" $ | nindent 12 }}
           annotations:
             checksum/config: {{ include (print $.Template.BasePath "/environment.yaml") $ | sha256sum }}

--- a/charts/seqr/templates/deployment.yaml
+++ b/charts/seqr/templates/deployment.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   name: {{ .Chart.Name }}
   labels:
+    name: {{ $.Chart.Name }}
     {{- include "seqr.labels" . | nindent 4 }}
   {{- with .Values.deploymentAnnotations }}
   annotations:
@@ -14,11 +15,13 @@ spec:
   revisionHistoryLimit: 5
   selector:
     matchLabels:
+      name: {{ $.Chart.Name }}
       {{- include "seqr.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       name: {{ .Chart.Name }}
       labels:
+        name: {{ $.Chart.Name }}
         {{- include "seqr.labels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/environment.yaml") . | sha256sum }}


### PR DESCRIPTION
Resolves a nasty bug w/ the selector pointing to long running cronjob pods.