### PR TITLE
Initial VLM chart

### DIFF
--- a/charts/seqr-platform/Chart.yaml
+++ b/charts/seqr-platform/Chart.yaml
@@ -21,6 +21,9 @@ dependencies:
   - name: hail-search
     version: 0.5.0
     repository: "https://broadinstitute.github.io/seqr-helm"
+  - name: vlm
+    version: 0.0.1
+    repository: "https://broadinstitute.github.io/seqr-helm"
   - name: lib
     version: 0.1.4
     repository: "https://broadinstitute.github.io/seqr-helm"

--- a/charts/seqr-platform/Chart.yaml
+++ b/charts/seqr-platform/Chart.yaml
@@ -21,9 +21,6 @@ dependencies:
   - name: hail-search
     version: 0.5.0
     repository: "https://broadinstitute.github.io/seqr-helm"
-  - name: vlm
-    version: 0.0.1
-    repository: "https://broadinstitute.github.io/seqr-helm"
   - name: lib
     version: 0.1.4
     repository: "https://broadinstitute.github.io/seqr-helm"

--- a/charts/vlm/.helmignore
+++ b/charts/vlm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/vlm/Chart.lock
+++ b/charts/vlm/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: lib
+  repository: file://../lib
+  version: 0.1.4
+digest: sha256:de7b5da1cb54e6de2e4cb3132349710500dd817989cfca0a419974da9a62a1a8
+generated: "2024-10-08T23:32:20.479906-04:00"

--- a/charts/vlm/Chart.lock
+++ b/charts/vlm/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: lib
-  repository: file://../lib
-  version: 0.1.4
-digest: sha256:de7b5da1cb54e6de2e4cb3132349710500dd817989cfca0a419974da9a62a1a8
-generated: "2024-10-08T23:32:20.479906-04:00"

--- a/charts/vlm/Chart.lock
+++ b/charts/vlm/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: lib
+  repository: file://../lib
+  version: 0.1.4
+digest: sha256:de7b5da1cb54e6de2e4cb3132349710500dd817989cfca0a419974da9a62a1a8
+generated: "2024-10-28T11:43:12.652276-04:00"

--- a/charts/vlm/Chart.yaml
+++ b/charts/vlm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: hail-search
-description: A Helm chart for deploying the hail backend of Seqr, an open source software platform for rare disease genomics
+name: vlm
+description: A Helm chart for deploying VLM within Seqr
 sources:
   - https://github.com/broadinstitute/seqr
   - https://github.com/broadinstitute/seqr-helm
@@ -11,12 +11,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "77e84647fa237fbb1fa02086598a1e11ae061ed3"
+appVersion: ""
 dependencies:
   - name: lib
     version: 0.1.4

--- a/charts/vlm/Chart.yaml
+++ b/charts/vlm/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: hail-search
+description: A Helm chart for deploying the hail backend of Seqr, an open source software platform for rare disease genomics
+sources:
+  - https://github.com/broadinstitute/seqr
+  - https://github.com/broadinstitute/seqr-helm
+maintainers:
+  - name: seqr
+    email: seqr@broadinstitute.org
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.5.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "77e84647fa237fbb1fa02086598a1e11ae061ed3"
+dependencies:
+  - name: lib
+    version: 0.1.4
+    repository: "file://../lib"
+    import-values:
+      - child: exports.global
+        parent: global

--- a/charts/vlm/README.md
+++ b/charts/vlm/README.md
@@ -1,8 +1,8 @@
-# hail-search
+# vlm
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 77e84647fa237fbb1fa02086598a1e11ae061ed3](https://img.shields.io/badge/AppVersion-77e84647fa237fbb1fa02086598a1e11ae061ed3-informational?style=flat-square)
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
-A Helm chart for deploying the hail backend of Seqr, an open source software platform for rare disease genomics
+A Helm chart for deploying VLM within Seqr
 
 ## Maintainers
 
@@ -59,19 +59,10 @@ false
 			<td></td>
 		</tr>
 		<tr>
-			<td>environment.HAIL_SEARCH_DATA_DIR</td>
+			<td>environment.VLM_DATA_DIR</td>
 			<td>string</td>
 			<td><pre lang="json">
 "/var/seqr/seqr-hail-search-data"
-</pre>
-</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>environment.REFERENCE_DATASETS_DIR</td>
-			<td>string</td>
-			<td><pre lang="json">
-"/var/seqr/seqr-reference-data"
 </pre>
 </td>
 			<td></td>
@@ -89,7 +80,7 @@ false
 			<td>image.repository</td>
 			<td>string</td>
 			<td><pre lang="json">
-"gcr.io/seqr-project/seqr-hail-search"
+"gcr.io/seqr-project/seqr-vlm"
 </pre>
 </td>
 			<td></td>
@@ -152,7 +143,7 @@ false
 			<td>service.port</td>
 			<td>int</td>
 			<td><pre lang="json">
-5000
+6000
 </pre>
 </td>
 			<td></td>

--- a/charts/vlm/README.md
+++ b/charts/vlm/README.md
@@ -1,0 +1,272 @@
+# hail-search
+
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 77e84647fa237fbb1fa02086598a1e11ae061ed3](https://img.shields.io/badge/AppVersion-77e84647fa237fbb1fa02086598a1e11ae061ed3-informational?style=flat-square)
+
+A Helm chart for deploying the hail backend of Seqr, an open source software platform for rare disease genomics
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| seqr | <seqr@broadinstitute.org> |  |
+
+## Source Code
+
+* <https://github.com/broadinstitute/seqr>
+* <https://github.com/broadinstitute/seqr-helm>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| file://../lib | lib | 0.1.4 |
+
+## Values
+
+<table>
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+		<tr>
+			<td>global.seqrPlatformDeploy</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>affinity</td>
+			<td>string</td>
+			<td><pre lang="json">
+"podAntiAffinity:\n  preferredDuringSchedulingIgnoredDuringExecution:\n    - weight: 1.0\n      podAffinityTerm:\n        labelSelector:\n          matchExpressions:\n            - key: \"app.kubernetes.io/part-of\"\n              operator: In\n              values:\n              - \"seqr-platform\"\n        topologyKey: \"kubernetes.io/hostname\""
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>deploymentAnnotations</td>
+			<td>object</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>environment.HAIL_SEARCH_DATA_DIR</td>
+			<td>string</td>
+			<td><pre lang="json">
+"/var/seqr/seqr-hail-search-data"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>environment.REFERENCE_DATASETS_DIR</td>
+			<td>string</td>
+			<td><pre lang="json">
+"/var/seqr/seqr-reference-data"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>image.pullPolicy</td>
+			<td>string</td>
+			<td><pre lang="json">
+"Always"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>image.repository</td>
+			<td>string</td>
+			<td><pre lang="json">
+"gcr.io/seqr-project/seqr-hail-search"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>imagePullSecrets</td>
+			<td>list</td>
+			<td><pre lang="json">
+[]
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>initContainers</td>
+			<td>object</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>nodeSelector</td>
+			<td>object</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>podAnnotations</td>
+			<td>object</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>replicaCount</td>
+			<td>int</td>
+			<td><pre lang="json">
+1
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>resources</td>
+			<td>object</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>service.port</td>
+			<td>int</td>
+			<td><pre lang="json">
+5000
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>service.type</td>
+			<td>string</td>
+			<td><pre lang="json">
+"ClusterIP"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>serviceAccount.annotations</td>
+			<td>object</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>serviceAccount.create</td>
+			<td>bool</td>
+			<td><pre lang="json">
+true
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>tolerations</td>
+			<td>list</td>
+			<td><pre lang="json">
+[]
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>volumeMounts</td>
+			<td>string</td>
+			<td><pre lang="json">
+"- name: seqr-datasets\n  mountPath: /var/seqr\n  readOnly: true"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>volumes</td>
+			<td>string</td>
+			<td><pre lang="json">
+"- name: seqr-datasets\n  persistentVolumeClaim:\n    readOnly: true\n    claimName: {{ include \"lib.pvc-name\" . }}"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>lib.exports.global.lib.persistentVolume.accessMode</td>
+			<td>string</td>
+			<td><pre lang="json">
+"ReadWriteOnce"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>lib.exports.global.lib.persistentVolume.csi</td>
+			<td>object</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>lib.exports.global.lib.persistentVolume.local.nodeSelector</td>
+			<td>string</td>
+			<td><pre lang="json">
+"kind-control-plane"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>lib.exports.global.lib.persistentVolume.local.path</td>
+			<td>string</td>
+			<td><pre lang="json">
+"/var/seqr"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>lib.exports.global.lib.persistentVolume.storageCapacity</td>
+			<td>string</td>
+			<td><pre lang="json">
+"750Gi"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>lib.exports.global.seqrPlatformDeploy</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td></td>
+		</tr>
+	</tbody>
+</table>
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/vlm/README.md.gotmpl
+++ b/charts/vlm/README.md.gotmpl
@@ -1,0 +1,18 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSectionHtml" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/vlm/templates/_helpers.tpl
+++ b/charts/vlm/templates/_helpers.tpl
@@ -1,9 +1,9 @@
 {{/*
 Common labels
 */}}
-{{- define "hail-search.labels" -}}
+{{- define "vlm.labels" -}}
 helm.sh/chart: {{printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{ include "hail-search.selectorLabels" . }}
+{{ include "vlm.selectorLabels" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: seqr-platform
@@ -12,7 +12,7 @@ app.kubernetes.io/part-of: seqr-platform
 {{/*
 Selector labels
 */}}
-{{- define "hail-search.selectorLabels" -}}
+{{- define "vlm.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/vlm/templates/_helpers.tpl
+++ b/charts/vlm/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{/*
+Common labels
+*/}}
+{{- define "hail-search.labels" -}}
+helm.sh/chart: {{printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "hail-search.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: seqr-platform
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hail-search.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/vlm/templates/deployment.yaml
+++ b/charts/vlm/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    {{- include "vlm.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      {{- include "vlm.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "vlm.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/environment.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.volumes }}
+      volumes:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-pod
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Chart.Name }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            failureThreshold: 5
+            httpGet:
+              path: /status
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            failureThreshold: 5
+            httpGet:
+              path: /status
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- tpl . $ | nindent 12 }}
+          {{- end }}
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+      {{- with .Values.initContainers}}
+      initContainers:
+        {{- tpl . $ | trim | nindent 8}}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/vlm/templates/environment.yaml
+++ b/charts/vlm/templates/environment.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    {{- include "vlm.labels" . | nindent 4 }}
+data:
+  {{- with .Values.environment }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/vlm/templates/persistentvolume.yaml
+++ b/charts/vlm/templates/persistentvolume.yaml
@@ -1,0 +1,3 @@
+{{- if not .Values.global.seqrPlatformDeploy }}
+{{- include "lib.persistentvolume" . }}
+{{- end }}

--- a/charts/vlm/templates/service.yaml
+++ b/charts/vlm/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    {{- include "vlm.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "vlm.selectorLabels" . | nindent 4 }}

--- a/charts/vlm/values.yaml
+++ b/charts/vlm/values.yaml
@@ -1,0 +1,56 @@
+replicaCount: 1
+
+image:
+  repository: gcr.io/seqr-project/seqr-hail-search
+  pullPolicy: Always
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  annotations: {}
+
+podAnnotations: {}
+deploymentAnnotations: {}
+
+service:
+  type: ClusterIP
+  port: 5000
+
+resources:
+  {}
+
+environment:
+  HAIL_SEARCH_DATA_DIR: '/var/seqr/seqr-hail-search-data'
+  REFERENCE_DATASETS_DIR: '/var/seqr/seqr-reference-data'
+
+volumes: |-
+  - name: seqr-datasets
+    persistentVolumeClaim:
+      readOnly: true
+      claimName: {{ include "lib.pvc-name" . }}
+volumeMounts: |-
+  - name: seqr-datasets
+    mountPath: /var/seqr
+    readOnly: true
+
+initContainers: {}
+
+affinity: |-
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1.0
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: "app.kubernetes.io/part-of"
+                operator: In
+                values:
+                - "seqr-platform"
+          topologyKey: "kubernetes.io/hostname"
+
+nodeSelector: {}
+tolerations: []
+
+global:
+  seqrPlatformDeploy: false

--- a/charts/vlm/values.yaml
+++ b/charts/vlm/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/seqr-project/seqr-hail-search
+  repository: gcr.io/seqr-project/seqr-vlm
   pullPolicy: Always
 
 imagePullSecrets: []
@@ -15,14 +15,13 @@ deploymentAnnotations: {}
 
 service:
   type: ClusterIP
-  port: 5000
+  port: 6000
 
 resources:
   {}
 
 environment:
-  HAIL_SEARCH_DATA_DIR: '/var/seqr/seqr-hail-search-data'
-  REFERENCE_DATASETS_DIR: '/var/seqr/seqr-reference-data'
+  VLM_DATA_DIR: '/var/seqr/seqr-hail-search-data'
 
 volumes: |-
   - name: seqr-datasets


### PR DESCRIPTION
Creates the basic VLM helm chart. The default behavior (which is what we want for local installs) *should* be to mount the same persistent volume that we use for the hail search data  to the vlm as a read-only volume, so that the VLM would be running on the same data