### PR TITLE
add egress policy to vlm pods

### DIFF
--- a/charts/vlm/templates/networkpolicy.yaml
+++ b/charts/vlm/templates/networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Chart.Name }}-deny-egress
+  labels:
+    {{- include "vlm.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "vlm.selectorLabels" . | nindent 4 }}
+  policyTypes:
+    - Egress


### PR DESCRIPTION
Instead of configuring linkerd, use kubernetes to block all egress traffic from the VLM