### PR TITLE
restrict pod to pod traffic

### DIFF
--- a/charts/seqr/README.md
+++ b/charts/seqr/README.md
@@ -585,6 +585,15 @@ true
 			<td></td>
 		</tr>
 		<tr>
+			<td>redis.networkPolicy.enabled</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
 			<td>replicaCount</td>
 			<td>int</td>
 			<td><pre lang="json">

--- a/charts/seqr/templates/networkpolicy.yaml
+++ b/charts/seqr/templates/networkpolicy.yaml
@@ -13,7 +13,7 @@ spec:
       - podSelector:
           matchLabels:
             app.kubernetes.io/name: {{ .Chart.Name }}
-      {{- if .Values.ingress.enabled -}}
+      {{- if .Values.ingress.enabled }}
       - namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: {{ .Values.ingress.namespaceLabel | default .Values.ingress.nameOverride }}

--- a/charts/seqr/templates/networkpolicy.yaml
+++ b/charts/seqr/templates/networkpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-cluster-deny-ingress
+  name: {{ .Chart.Name }}-only-ingress
 spec:
   podSelector:
     matchLabels:
@@ -12,7 +12,9 @@ spec:
     - from:
       - podSelector:
           matchLabels:
-            app.kubernetes.io/name: seqr
+            app.kubernetes.io/name: {{ .Chart.Name }}
+      {{- if .Values.ingress.enabled -}}
       - namespaceSelector:
           matchLabels:
-            kubernetes.io/metadata.name: ingress-nginx
+            kubernetes.io/metadata.name: {{ .Values.ingress.namespaceLabel | default .Values.ingress.nameOverride }}
+      {{- end }}

--- a/charts/seqr/values.yaml
+++ b/charts/seqr/values.yaml
@@ -109,6 +109,8 @@ redis:
   architecture: standalone
   auth:
     enabled: false
+  networkPolicy:
+    enabled: false
   fullnameOverride: "seqr-redis"
 
 postgresql:


### PR DESCRIPTION
I wrote a NetworkPolicy which restricts traffic between pods within the seqr cluster. It blocks any ingress to all  the pods in a given release unless traffic is coming from the seqr pod itself or nginx (so external traffic still works). This means that while the seqr pod can still access all dependent services like hail-search, those services can not access seqr back and also can not access each other. This is consistent with how we actually expect these services to behave, and is required for the VLM which would be a security risk if it was able to access hail search or redis or other dependent services

This policy is currently live in dev and working as expected. I made it part of the VLM release so its currently only enabled if the whole VLM is enabled. However, I think this is a good policy to have in general so I think we should move this to the main seqr release and always have it configured on. This PR would move it to the seqr release and also switch some hard coded strings to values

For local installs if you are running kubernetes in an environment that does not suppot Networking then this will not do anything, but it also will not throw any errors. Kubernetes just ignores these if they are in an environment that doesn't support networking (ask me how I know :)) so theres no harm in including it by default AFAIK