### PR TITLE
add gh action to run helm-docs

### DIFF
--- a/.github/workflows/update_chart_docs.yaml
+++ b/.github/workflows/update_chart_docs.yaml
@@ -1,0 +1,24 @@
+name: update chart docs
+
+# Update chart READMEs with helm-docs on pushes (incl. merges) to main
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  update_chart_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run helm-docs
+        uses: losisin/helm-docs-github-action@v1
+        with:
+          chart-search-root: charts
+          git-push: true


### PR DESCRIPTION
Ideally `helm-docs` is run locally on every commit using the pre-commit hook, but this PR adds an action to automate updating the docs on pushes/PR merges. This is useful for the `seqr` and `hail-search` chart `version` and `appVersion` bumps which are triggered via a github action in `seqr`: https://github.com/broadinstitute/seqr/pull/4534. 

I found a github action that allegedly does this for us: https://github.com/losisin/helm-docs-github-action