### PR TITLE
remove unused option from update_all_reference_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,11 @@ helm repo update
 helm upgrade YOUR_INSTITUTION_NAME-seqr seqr-helm/seqr-platform
 ```
 
-To update reference data in seqr, such as OMIM, HPO, etc., run the following
+To update reference data in seqr, such as OMIM, HPO, etc., run the following. By default, this will be run automatically 
+as a cron job.
 ```bash
 kubectl exec seqr-POD-ID -c seqr -it -- bash
-python3 /seqr/manage.py update_all_reference_data --use-cached-omim --skip-gencode
+python3 /seqr/manage.py update_all_reference_data
 ```
 
 ## Debugging FAQ

--- a/charts/seqr/README.md
+++ b/charts/seqr/README.md
@@ -84,7 +84,7 @@ A Helm chart for deploying the Seqr app, an open source software platform for ra
 			<td>cronJobs[1].command</td>
 			<td>string</td>
 			<td><pre lang="json">
-"python manage.py update_all_reference_data --use-cached-omim"
+"python manage.py update_all_reference_data"
 </pre>
 </td>
 			<td></td>

--- a/charts/seqr/values.yaml
+++ b/charts/seqr/values.yaml
@@ -101,7 +101,7 @@ cronJobs:
     command: "python manage.py check_for_new_samples_from_pipeline"
   - name: update-all-reference-data
     schedule: "*/5 * * * *"
-    command: "python manage.py update_all_reference_data --use-cached-omim"
+    command: "python manage.py update_all_reference_data"
 
 updateAllReferenceDataPostInstallJob:
   enabled: true


### PR DESCRIPTION
This [pending seqr release](https://github.com/broadinstitute/seqr/pull/4737) changes the arguments used for calling the `update_all_reference_data` command. By merging this PR before releasing that code, the version of the seqr chart that will be automatically built when that seqr PR is merged will include compatible manage command calls and we will not generate an invalid chart