### PR TITLE
Support additional configd and usersd files

### DIFF
--- a/charts/seqr/Chart.yaml
+++ b/charts/seqr/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
   - name: seqr
     email: seqr@broadinstitute.org
 type: application
-version: 3.5.2
+version: 3.5.3
 appVersion: "df265fdbf6e7623e15b07b76f2a3078bca3dfd9e"
 dependencies:
   - name: redis

--- a/charts/seqr/README.md
+++ b/charts/seqr/README.md
@@ -1,6 +1,6 @@
 # seqr
 
-![Version: 3.5.2](https://img.shields.io/badge/Version-3.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: df265fdbf6e7623e15b07b76f2a3078bca3dfd9e](https://img.shields.io/badge/AppVersion-df265fdbf6e7623e15b07b76f2a3078bca3dfd9e-informational?style=flat-square)
+![Version: 3.5.3](https://img.shields.io/badge/Version-3.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: df265fdbf6e7623e15b07b76f2a3078bca3dfd9e](https://img.shields.io/badge/AppVersion-df265fdbf6e7623e15b07b76f2a3078bca3dfd9e-informational?style=flat-square)
 
 A Helm chart for deploying the Seqr app, an open source software platform for rare disease genomics
 
@@ -55,7 +55,25 @@ A Helm chart for deploying the Seqr app, an open source software platform for ra
 			<td></td>
 		</tr>
 		<tr>
+			<td>clickhouse.additionalConfigdFiles</td>
+			<td>object</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
 			<td>clickhouse.additionalSidecars</td>
+			<td>object</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>clickhouse.additionalUsersdFiles</td>
 			<td>object</td>
 			<td><pre lang="json">
 {}

--- a/charts/seqr/templates/clickhouseconfig.yaml
+++ b/charts/seqr/templates/clickhouseconfig.yaml
@@ -44,6 +44,9 @@ data:
       </named_collections>
     </clickhouse>
   {{- end }}
+  {{- with $.Values.clickhouse.additionalConfigdFiles }}
+    {{- tpl . $ | nindent 2}}
+  {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -125,4 +128,7 @@ data:
         </{{ $.Values.environment.CLICKHOUSE_VLM_USERNAME }}>
       </users>
     </clickhouse>
+  {{- with $.Values.clickhouse.additionalUsersdFiles }}
+    {{- tpl . $ | nindent 2}}
+  {{- end }}
 {{- end }}

--- a/charts/seqr/values.yaml
+++ b/charts/seqr/values.yaml
@@ -342,6 +342,8 @@ clickhouse:
   initdbScriptsSecret: seqr-clickhouse-init-db-secret
   initdbSecretEnabled: true  # note this is not a clickhouse chart variable, but controls seqr's db initialization.
   additionalSidecars: {}  # note this is not a clickhouse chart variable.
+  additionalConfigdFiles: {}
+  additionalUsersdFiles: {}
 global:
   seqr:
     environment:

--- a/unit_test/seqr/values.yaml
+++ b/unit_test/seqr/values.yaml
@@ -135,3 +135,12 @@ clickhouse:
         - name: data
           mountPath: |-
             {{ .Values.persistence.mountPath }}
+  additionalUsersdFiles: |-
+    02_deployment_seqr_users_config.xml: 
+      <clickhouse>
+        <profiles>
+          <default>
+            <an_internal_setting>0</an_internal_setting>
+          </default>
+        </profiles>
+      </clickhouse>


### PR DESCRIPTION
The Bitnami helm chart doesn't work with both config maps and overrides, this builds our own. 