### PR TITLE
Image pull policy

### DIFF
--- a/charts/pipeline-runner/README.md
+++ b/charts/pipeline-runner/README.md
@@ -197,7 +197,7 @@ false
 			<td>image.pullPolicy</td>
 			<td>string</td>
 			<td><pre lang="json">
-"Always"
+"IfNotPresent"
 </pre>
 </td>
 			<td></td>

--- a/charts/pipeline-runner/values.yaml
+++ b/charts/pipeline-runner/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gcr.io/seqr-project/seqr-pipeline-runner
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 imagePullSecrets: []
 
 serviceAccount:

--- a/charts/seqr/README.md
+++ b/charts/seqr/README.md
@@ -397,6 +397,15 @@ true
 			<td></td>
 		</tr>
 		<tr>
+			<td>clickhouse.image.pullPolicy</td>
+			<td>string</td>
+			<td><pre lang="json">
+"IfNotPresent"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
 			<td>clickhouse.image.registry</td>
 			<td>string</td>
 			<td><pre lang="json">
@@ -1237,7 +1246,7 @@ false
 			<td>image.pullPolicy</td>
 			<td>string</td>
 			<td><pre lang="json">
-"Always"
+"IfNotPresent"
 </pre>
 </td>
 			<td></td>

--- a/charts/seqr/values.yaml
+++ b/charts/seqr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: gcr.io/seqr-project/seqr
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 imagePullSecrets: []
 
 serviceAccount:
@@ -207,6 +207,7 @@ clickhouse:
     registry: "gcr.io"
     repository: "seqr-project/seqr-clickhouse"
     tag: "26.3.9"
+    pullPolicy: IfNotPresent
   fullnameOverride: seqr-clickhouse
   shards: 1
   replicaCount: 1


### PR DESCRIPTION
Updates the image pull policies for both the seqr and pipeline-runner Helm charts from Always to IfNotPresent. This optimization reduces unnecessary image pulls from the container registry when an image with the same tag already exists locally. Also adds explicit pullPolicy configuration for the ClickHouse image.

Changes

- seqr chart:
  - Changed primary image pullPolicy from Always to IfNotPresent
  - Added pullPolicy: IfNotPresent to ClickHouse image configuration
  - Updated README to document both changes
- pipeline-runner chart:
  - Changed image pullPolicy from Always to IfNotPresent
  - Updated README to reflect the change

Benefits

- Reduces unnecessary image registry calls and bandwidth usage
- Faster deployments when images are already cached locally
- More efficient resource utilization across cluster nodes